### PR TITLE
Publish to AUR

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,0 +1,17 @@
+pkgbase = kf6-service-menu-reimage
+	pkgdesc = Manipulate images e their metadata
+	pkgver = 2.6.0
+	pkgrel = 1
+	url = https://github.com/irfanhakim-as/kde-service-menu-reimage
+	arch = any
+	license = GPL-3.0+
+	depends = dolphin
+	depends = imagemagick
+	depends = kdialog
+	optdepends = jhead: required for extracting exif data
+	conflicts = kde-service-menu-reimage
+	conflicts = kde-service-menu-reimage-mod
+	source = https://github.com/irfanhakim-as/kde-service-menu-reimage/releases/download/v2.6.0/kde-service-menu-reimage_2.6.0_any.tar.gz
+	md5sums = acc6ec84363579911b366e62ff79bb22
+
+pkgname = kf6-service-menu-reimage

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -46,33 +46,33 @@ jobs:
           # clone remote repository
           git clone ${REMOTE_HOST_PREFIX}${REMOTE_HOST_USER:-git}@${REMOTE_HOST}${REMOTE_REPO_NAMESPACE}/${REMOTE_REPO_NAME}.git
 
-      - name: Copy PKGBUILD to remote repository
-        id: copy_pkgbuild
+      - name: Copy package files to remote repository
+        id: copy_pkgfiles
         run: |
-          cp PKGBUILD ${REMOTE_REPO_NAME}/PKGBUILD
+          cp .SRCINFO PKGBUILD ${REMOTE_REPO_NAME}/
 
-      - name: Check if PKGBUILD has changes
+      - name: Check if package files have changes
         id: check_changes
         run: |
           # change working directory
           cd ${REMOTE_REPO_NAME}
 
-          # add PKGBUILD
-          git add PKGBUILD
+          # add package files
+          git add .SRCINFO PKGBUILD
 
           # check for changes
           if git diff --cached --exit-code >/dev/null; then
-            echo "No changes have been made to PKGBUILD."
+            echo "No changes have been made to the package files."
             exists=false
           else
-            echo "PKGBUILD has been updated and is pending commit."
+            echo "Package files have been updated and are pending commit."
             exists=true
           fi
 
           # export result to output
           echo "exists=${exists}" | tee -a ${GITHUB_OUTPUT}
 
-      - name: Commit and push updated PKGBUILD
+      - name: Commit and push updated package files
         id: push_changes
         if: steps.check_changes.outputs.exists == 'true'
         run: |

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -1,0 +1,95 @@
+name: Update AUR
+
+on:
+  push:
+    branches:
+      - master                    # monitor changes only in the master branch
+    paths:
+      - PKGBUILD                  # monitor changes to the PKGBUILD file
+  workflow_dispatch:              # allow manually triggering the workflow
+
+env:
+  REMOTE_HOST: aur.archlinux.org
+  REMOTE_HOST_USER: aur
+  REMOTE_HOST_PREFIX: ssh
+  REMOTE_REPO_NAMESPACE: ''
+  REMOTE_REPO_NAME: kf6-service-menu-reimage
+  REMOTE_REPO_USER: irfanhakim
+  REMOTE_REPO_EMAIL: irfanhakim.as@yahoo.com
+
+jobs:
+  update-aur:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        id: checkout
+        uses: actions/checkout@v3
+
+      - name: Set up SSH
+        id: configure_ssh
+        uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.AUR_PRIVATE_KEY }}
+
+      - name: Add remote host to known hosts
+        id: add_remote_host
+        run: |
+          ssh-keyscan ${REMOTE_HOST} >> ~/.ssh/known_hosts
+
+      - name: Clone the remote repository
+        id: clone_remote_repo
+        run: |
+          # set variables
+          REMOTE_HOST_PREFIX="${{ env.REMOTE_HOST_PREFIX }}${{ env.REMOTE_HOST_PREFIX && '://' }}"
+          REMOTE_REPO_NAMESPACE="${{ env.REMOTE_REPO_NAMESPACE && ':' }}${{ env.REMOTE_REPO_NAMESPACE }}"
+
+          # clone remote repository
+          git clone ${REMOTE_HOST_PREFIX}${REMOTE_HOST_USER:-git}@${REMOTE_HOST}${REMOTE_REPO_NAMESPACE}/${REMOTE_REPO_NAME}.git
+
+      - name: Copy PKGBUILD to remote repository
+        id: copy_pkgbuild
+        run: |
+          cp PKGBUILD ${REMOTE_REPO_NAME}/PKGBUILD
+
+      - name: Check if PKGBUILD has changes
+        id: check_changes
+        run: |
+          # change working directory
+          cd ${REMOTE_REPO_NAME}
+
+          # add PKGBUILD
+          git add PKGBUILD
+
+          # check for changes
+          if git diff --cached --exit-code >/dev/null; then
+            echo "No changes have been made to PKGBUILD."
+            exists=false
+          else
+            echo "PKGBUILD has been updated and is pending commit."
+            exists=true
+          fi
+
+          # export result to output
+          echo "exists=${exists}" | tee -a ${GITHUB_OUTPUT}
+
+      - name: Commit and push updated PKGBUILD
+        id: push_changes
+        if: steps.check_changes.outputs.exists == 'true'
+        run: |
+          # set variables
+          source PKGBUILD
+          version="${pkgver}"
+          release="${pkgrel}"
+
+          # change working directory
+          cd ${REMOTE_REPO_NAME}
+
+          # configure git
+          git config --local user.name "${REMOTE_REPO_USER:-github-actions[bot]}"
+          git config --local user.email "${REMOTE_REPO_EMAIL:-github-actions[bot]@users.noreply.github.com}"
+
+          # commit changes
+          git commit -m "Update to ${version}-${pkgrel}"
+
+          # push commit
+          git push -u origin HEAD

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,6 @@ on:
 permissions:
   contents: write
 
-env:
-  METADATA_FILE: "doc/package.conf"
-
 jobs:
   metadata:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
     paths:
       - doc/package.conf          # monitor changes to the package metadata file
 
-permissions:
-  contents: write
-
 env:
   GH_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
 
@@ -78,8 +75,6 @@ jobs:
 
           # export result to output
           echo "exists=${exists}" | tee -a ${GITHUB_OUTPUT}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   go:
     runs-on: ubuntu-latest
@@ -220,8 +215,6 @@ jobs:
             --notes "$(echo -e "${release_notes}")" \
             --target "${main_branch}" \
             --generate-notes
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload assets to release
         id: upload_asset
@@ -232,5 +225,3 @@ jobs:
 
           # upload asset to the GitHub release
           gh release upload "v${version}" "${asset}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,23 @@ jobs:
           echo "asset=${asset}" | tee -a ${GITHUB_OUTPUT}
           echo "md5sum=$(md5sum "${asset}" | awk '{print $1}')" | tee -a ${GITHUB_OUTPUT}
 
+      - name: Update PKGBUILD
+        id: update_pkgbuild
+        run: |
+          # set variables
+          version="${{ needs.metadata.outputs.version }}"
+          release="1"
+          md5sum="${{ steps.package_asset.outputs.md5sum }}"
+
+          # update pkgver in PKGBUILD
+          sed -i "s/^pkgver=.*/pkgver=${version}/" PKGBUILD
+
+          # reset the pkgrel number to 1
+          sed -i "s/^pkgrel=.*/pkgrel=${release}/" PKGBUILD
+
+          # update the md5sums array with the new md5sum
+          sed -i "s/^md5sums=.*/md5sums=('${md5sum}')/" PKGBUILD
+
       - name: Check if files have changes
         id: check_changes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,16 @@ jobs:
           # update the md5sums array with the new md5sum
           sed -i "s/^md5sums=.*/md5sums=('${md5sum}')/" PKGBUILD
 
+      - name: Update SRCINFO
+        id: update_srcinfo
+        run: |
+          docker run --rm -v ${PWD}:/pkgbuild -w /pkgbuild archlinux:base-devel bash -c "
+          pacman -Sy --noconfirm base-devel && \
+          useradd builder -m && \
+          echo 'builder ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers && \
+          chmod -R a+rw . && \
+          sudo -u builder makepkg --printsrcinfo > .SRCINFO"
+
       - name: Check if files have changes
         id: check_changes
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Update version in source code
+      - name: Update version in source files
         id: update_version
         run: |
           # set variables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,17 @@ env:
   METADATA_FILE: "doc/package.conf"
 
 jobs:
-  release:
+  metadata:
     runs-on: ubuntu-latest
-
+    env:
+      METADATA_FILE: "demo/package.conf"
+      REQUIRED_VARS: "namespace version arch"
+    outputs:
+      version: ${{ steps.get_metadata.outputs.version }}
+      namespace: ${{ steps.get_metadata.outputs.namespace }}
+      arch: ${{ steps.get_metadata.outputs.arch }}
     steps:
-      - name: Check out the code
+      - name: Check out the repository
         id: checkout
         uses: actions/checkout@v3
         with:
@@ -27,13 +33,10 @@ jobs:
       - name: Source metadata file and export variables
         id: get_metadata
         run: |
-          # set required variables
-          required_vars=("namespace" "version" "arch")
-
           # source values from metadata file
           source "${METADATA_FILE}"
 
-          for var in "${required_vars[@]}"; do
+          for var in ${REQUIRED_VARS}; do
             # ensure variable is set
             key="__${var}__"
             if [ -z "${!key}" ]; then
@@ -44,23 +47,85 @@ jobs:
             echo "${var}=${!key}" | tee -a ${GITHUB_OUTPUT}
           done
 
+  check:
+    runs-on: ubuntu-latest
+    needs: metadata
+    outputs:
+      release_exists: ${{ steps.check_release.outputs.exists }}
+    steps:
+      - name: Check out the repository
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Check if release exists
+        id: check_release
+        run: |
+          # set variables
+          version="${{ needs.metadata.outputs.version }}"
+
+          # check if release of said version exists
+          if [[ "$(gh release view "v${version}" 2>&1)" == "release not found" ]]; then
+            echo "Release v${version} has not been created."
+            exists=false
+          else
+            echo "Release v${version} already exists."
+            exists=true
+          fi
+
+          # export result to output
+          echo "exists=${exists}" | tee -a ${GITHUB_OUTPUT}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  go:
+    runs-on: ubuntu-latest
+    needs: [metadata, check]
+    if: needs.check.outputs.release_exists == 'false'
+    steps:
+      - name: Check out the repository
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Update version in source code
         id: update_version
         run: |
+          # set variables
+          version="${{ needs.metadata.outputs.version }}"
+
           # update version badge in markdown files
-          find . -type f -name "*.md" -exec sed -i "s/\(Version-\)[0-9]*\.[0-9]*\.[0-9]*\(-informational\)/\1${{ steps.get_metadata.outputs.version }}\2/g;s/\[Version: [0-9]*\.[0-9]*\.[0-9]*\]/\[Version: ${{ steps.get_metadata.outputs.version }}\]/g" {} +
+          find . -type f -name "*.md" -exec sed -i "s/\(Version-\)[0-9]*\.[0-9]*\.[0-9]*\(-informational\)/\1${version}\2/g;s/\[Version: [0-9]*\.[0-9]*\.[0-9]*\]/\[Version: ${version}\]/g" {} +
 
           # update version in shell files
-          find . -type f -name "*.sh" -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${{ steps.get_metadata.outputs.version }})/g" {} +
+          find . -type f -name "*.sh" -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${version})/g" {} +
 
           # update version in binary files
-          find ./bin -type f -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${{ steps.get_metadata.outputs.version }})/g" {} +
+          find ./bin -type f -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${version})/g" {} +
 
           # update version in config files
-          find ./doc -type f -name "*.config" -exec sed -i "s/version=.*/version=${{ steps.get_metadata.outputs.version }}/g" {} +
+          find ./doc -type f -name "*.config" -exec sed -i "s/version=.*/version=${version}/g" {} +
 
           # update version in service menu .desktop files
-          find ./ServiceMenus -type f -name "*.desktop" -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${{ steps.get_metadata.outputs.version }})/g" {} +
+          find ./ServiceMenus -type f -name "*.desktop" -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${version})/g" {} +
+
+      - name: Package assets into archive
+        id: package_asset
+        run: |
+          # set package values
+          name="${{ needs.metadata.outputs.namespace }}"
+          version="${{ needs.metadata.outputs.version }}"
+          arch="${{ needs.metadata.outputs.arch }}"
+          asset="${name}_${version}_${arch}.tar.gz"
+
+          # package required assets into a tar.gz file
+          tar -czvf "${asset}" bin doc ServiceMenus *.sh README.md
+
+          # export result to output
+          echo "asset=${asset}" | tee -a ${GITHUB_OUTPUT}
+          echo "md5sum=$(md5sum "${asset}" | awk '{print $1}')" | tee -a ${GITHUB_OUTPUT}
 
       - name: Check if files have changes
         id: check_changes
@@ -70,112 +135,65 @@ jobs:
 
           # determine if changes were made
           if git diff --cached --exit-code >/dev/null; then
-            echo "Changes have not been made."
+            echo "No changes have been made."
             exists=false
           else
-            echo "Changes have been made that are pending commit."
+            echo "Changes have been made and are pending commit."
             exists=true
           fi
 
           # export result to output
-          echo "exists=${exists}" >> ${GITHUB_OUTPUT}
+          echo "exists=${exists}" | tee -a ${GITHUB_OUTPUT}
 
       - name: Commit and push updated files
         id: commit_changes
         if: steps.check_changes.outputs.exists == 'true'
         run: |
+          # set variables
+          version="${{ needs.metadata.outputs.version }}"
+
           # configure git user
           git config --local user.name "github-actions[bot]"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
           # commit changes
-          git commit -m "Bump version to ${{ steps.get_metadata.outputs.version }}"
+          git commit -m "Bump version to ${version}"
 
           # push changes to current remote branch
           git push -u origin HEAD
 
-      - name: Check if release exists
-        id: check_release
-        run: |
-          # check if release of current version exists
-          if [[ "$(gh release view "v${{ steps.get_metadata.outputs.version }}" 2>&1)" == "release not found" ]]; then
-            echo "Release v${{ steps.get_metadata.outputs.version }} has not been created."
-            exists=false
-          else
-            echo "Release v${{ steps.get_metadata.outputs.version }} already exists."
-            exists=true
-          fi
-
-          # export result to output
-          echo "exists=${exists}" >> ${GITHUB_OUTPUT}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get previous release tag
-        id: get_prev_tag
-        if: steps.check_release.outputs.exists == 'false'
-        run: |
-          # determine previous tag
-          prev_tag=$(git describe --tags --abbrev=0 HEAD^ || echo "")
-
-          # check if previous tag exists
-          if [ -z "${prev_tag}" ]; then
-            echo "No previous tag found, this might be the first release."
-            prev_tag="HEAD" # use HEAD to include all commits
-          fi
-
-          # export result to output
-          echo "Previous version: ${prev_tag}"
-          echo "prev_tag=${prev_tag}" >> ${GITHUB_OUTPUT}
-
       - name: Get commit messages since last release
         id: get_commits
-        if: steps.check_release.outputs.exists == 'false'
         run: |
           # get previous version
-          prev_version="${{ steps.get_prev_tag.outputs.prev_tag }}"
+          prev_version=$(git describe --tags --abbrev=0 HEAD^ || echo "HEAD")
 
           # get commits between versions
-          if [[ "${prev_version}" == "HEAD" ]]; then
-            commits="$(git log --oneline | base64 -w 0)"
-          else
-            commits="$(git log "${prev_version}"..HEAD --oneline | base64 -w 0)"
+          if [[ "${prev_version}" != "HEAD" ]]; then
+            prev_version="${prev_version}..HEAD"
           fi
+          commits="$(git log "${prev_version}" --oneline | base64 -w 0)"
 
           # export result to output
-          echo "Latest commits: ${commits}"
-          echo "commits=${commits}" >> ${GITHUB_OUTPUT}
-
-      - name: Package assets into archive
-        id: package_asset
-        if: steps.check_release.outputs.exists == 'false'
-        run: |
-          # set package values
-          name="${{ steps.get_metadata.outputs.namespace }}"
-          version="${{ steps.get_metadata.outputs.version }}"
-          arch="${{ steps.get_metadata.outputs.arch }}"
-          asset="${name}_${version}_${arch}.tar.gz"
-
-          # package required assets into a tar.gz file
-          tar -czvf "${asset}" bin doc ServiceMenus *.sh README.md
-
-          # export asset path
-          echo "asset=${asset}" >> ${GITHUB_OUTPUT}
+          echo "commits=${commits}" | tee -a ${GITHUB_OUTPUT}
 
       - name: Create GitHub release
         id: create_release
-        if: steps.package_asset.conclusion == 'success'
         run: |
+          # set variables
+          version="${{ needs.metadata.outputs.version }}"
+          commits="${{ steps.get_commits.outputs.commits }}"
+
           # determine main branch
           main_branch=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
           # decode the commit messages
-          decoded_commits=$(echo "${{ steps.get_commits.outputs.commits }}" | base64 --decode)
+          decoded_commits=$(echo "${commits}" | base64 --decode)
           # prepare release notes
-          release_notes="Release v${{ steps.get_metadata.outputs.version }}.\n\n**Changes**:\n\n${decoded_commits}"
+          release_notes="Release v${version}.\n\n**Changes**:\n\n${decoded_commits}"
 
           # create release
-          gh release create "v${{ steps.get_metadata.outputs.version }}" \
-            --title "v${{ steps.get_metadata.outputs.version }}" \
+          gh release create "v${version}" \
+            --title "v${version}" \
             --notes "$(echo -e "${release_notes}")" \
             --target "${main_branch}" \
             --generate-notes
@@ -184,9 +202,12 @@ jobs:
 
       - name: Upload assets to release
         id: upload_asset
-        if: steps.package_asset.conclusion == 'success' && steps.create_release.conclusion == 'success'
         run: |
+          # set variables
+          version="${{ needs.metadata.outputs.version }}"
+          asset="${{ steps.package_asset.outputs.asset }}"
+
           # upload asset to the GitHub release
-          gh release upload "v${{ steps.get_metadata.outputs.version }}" "${{ steps.package_asset.outputs.asset }}"
+          gh release upload "v${version}" "${asset}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,8 +147,11 @@ jobs:
       - name: Check if files have changes
         id: check_changes
         run: |
-          # add local files
-          git add .
+          # set variables
+          asset="${{ steps.package_asset.outputs.asset }}"
+
+          # add local files except asset
+          git add . -- ":!${asset}"
 
           # determine if changes were made
           if git diff --cached --exit-code >/dev/null; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Update Version and Create Release
+name: Manage version, release, and PKGBUILD
 
 on:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,175 +18,175 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Check out the code
-      id: checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
+      - name: Check out the code
+        id: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: Source metadata file and export variables
-      id: get_metadata
-      run: |
-        # set required variables
-        required_vars=("namespace" "version" "arch")
+      - name: Source metadata file and export variables
+        id: get_metadata
+        run: |
+          # set required variables
+          required_vars=("namespace" "version" "arch")
 
-        # source values from metadata file
-        source "${METADATA_FILE}"
+          # source values from metadata file
+          source "${METADATA_FILE}"
 
-        for var in "${required_vars[@]}"; do
-          # ensure variable is set
-          key="__${var}__"
-          if [ -z "${!key}" ]; then
-            echo "ERROR: Required variable \"${key}\" was not set successfully."
-            exit 1
+          for var in "${required_vars[@]}"; do
+            # ensure variable is set
+            key="__${var}__"
+            if [ -z "${!key}" ]; then
+              echo "ERROR: Required variable \"${key}\" was not set successfully."
+              exit 1
+            fi
+            # export variable to output
+            echo "${var}=${!key}" | tee -a ${GITHUB_OUTPUT}
+          done
+
+      - name: Update version in source code
+        id: update_version
+        run: |
+          # update version badge in markdown files
+          find . -type f -name "*.md" -exec sed -i "s/\(Version-\)[0-9]*\.[0-9]*\.[0-9]*\(-informational\)/\1${{ steps.get_metadata.outputs.version }}\2/g;s/\[Version: [0-9]*\.[0-9]*\.[0-9]*\]/\[Version: ${{ steps.get_metadata.outputs.version }}\]/g" {} +
+
+          # update version in shell files
+          find . -type f -name "*.sh" -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${{ steps.get_metadata.outputs.version }})/g" {} +
+
+          # update version in binary files
+          find ./bin -type f -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${{ steps.get_metadata.outputs.version }})/g" {} +
+
+          # update version in config files
+          find ./doc -type f -name "*.config" -exec sed -i "s/version=.*/version=${{ steps.get_metadata.outputs.version }}/g" {} +
+
+          # update version in service menu .desktop files
+          find ./ServiceMenus -type f -name "*.desktop" -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${{ steps.get_metadata.outputs.version }})/g" {} +
+
+      - name: Check if files have changes
+        id: check_changes
+        run: |
+          # add local files
+          git add .
+
+          # determine if changes were made
+          if git diff --cached --exit-code >/dev/null; then
+            echo "Changes have not been made."
+            exists=false
+          else
+            echo "Changes have been made that are pending commit."
+            exists=true
           fi
-          # export variable to output
-          echo "${var}=${!key}" | tee -a ${GITHUB_OUTPUT}
-        done
 
-    - name: Update version in source code
-      id: update_version
-      run: |
-        # update version badge in markdown files
-        find . -type f -name "*.md" -exec sed -i "s/\(Version-\)[0-9]*\.[0-9]*\.[0-9]*\(-informational\)/\1${{ steps.get_metadata.outputs.version }}\2/g;s/\[Version: [0-9]*\.[0-9]*\.[0-9]*\]/\[Version: ${{ steps.get_metadata.outputs.version }}\]/g" {} +
+          # export result to output
+          echo "exists=${exists}" >> ${GITHUB_OUTPUT}
 
-        # update version in shell files
-        find . -type f -name "*.sh" -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${{ steps.get_metadata.outputs.version }})/g" {} +
+      - name: Commit and push updated files
+        id: commit_changes
+        if: steps.check_changes.outputs.exists == 'true'
+        run: |
+          # configure git user
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
 
-        # update version in binary files
-        find ./bin -type f -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${{ steps.get_metadata.outputs.version }})/g" {} +
+          # commit changes
+          git commit -m "Bump version to ${{ steps.get_metadata.outputs.version }}"
 
-        # update version in config files
-        find ./doc -type f -name "*.config" -exec sed -i "s/version=.*/version=${{ steps.get_metadata.outputs.version }}/g" {} +
+          # push changes to current remote branch
+          git push -u origin HEAD
 
-        # update version in service menu .desktop files
-        find ./ServiceMenus -type f -name "*.desktop" -exec sed -i -E "s/kde-service-menu-reimage \(version [0-9]+\.[0-9]+(\.[0-9]+)?\)/kde-service-menu-reimage (version ${{ steps.get_metadata.outputs.version }})/g" {} +
+      - name: Check if release exists
+        id: check_release
+        run: |
+          # check if release of current version exists
+          if [[ "$(gh release view "v${{ steps.get_metadata.outputs.version }}" 2>&1)" == "release not found" ]]; then
+            echo "Release v${{ steps.get_metadata.outputs.version }} has not been created."
+            exists=false
+          else
+            echo "Release v${{ steps.get_metadata.outputs.version }} already exists."
+            exists=true
+          fi
 
-    - name: Check if files have changes
-      id: check_changes
-      run: |
-        # add local files
-        git add .
+          # export result to output
+          echo "exists=${exists}" >> ${GITHUB_OUTPUT}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        # determine if changes were made
-        if git diff --cached --exit-code >/dev/null; then
-          echo "Changes have not been made."
-          exists=false
-        else
-          echo "Changes have been made that are pending commit."
-          exists=true
-        fi
+      - name: Get previous release tag
+        id: get_prev_tag
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          # determine previous tag
+          prev_tag=$(git describe --tags --abbrev=0 HEAD^ || echo "")
 
-        # export result to output
-        echo "exists=${exists}" >> ${GITHUB_OUTPUT}
+          # check if previous tag exists
+          if [ -z "${prev_tag}" ]; then
+            echo "No previous tag found, this might be the first release."
+            prev_tag="HEAD" # use HEAD to include all commits
+          fi
 
-    - name: Commit and push updated files
-      id: commit_changes
-      if: steps.check_changes.outputs.exists == 'true'
-      run: |
-        # configure git user
-        git config --local user.name "github-actions[bot]"
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          # export result to output
+          echo "Previous version: ${prev_tag}"
+          echo "prev_tag=${prev_tag}" >> ${GITHUB_OUTPUT}
 
-        # commit changes
-        git commit -m "Bump version to ${{ steps.get_metadata.outputs.version }}"
+      - name: Get commit messages since last release
+        id: get_commits
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          # get previous version
+          prev_version="${{ steps.get_prev_tag.outputs.prev_tag }}"
 
-        # push changes to current remote branch
-        git push -u origin HEAD
+          # get commits between versions
+          if [[ "${prev_version}" == "HEAD" ]]; then
+            commits="$(git log --oneline | base64 -w 0)"
+          else
+            commits="$(git log "${prev_version}"..HEAD --oneline | base64 -w 0)"
+          fi
 
-    - name: Check if release exists
-      id: check_release
-      run: |
-        # check if release of current version exists
-        if [[ "$(gh release view "v${{ steps.get_metadata.outputs.version }}" 2>&1)" == "release not found" ]]; then
-          echo "Release v${{ steps.get_metadata.outputs.version }} has not been created."
-          exists=false
-        else
-          echo "Release v${{ steps.get_metadata.outputs.version }} already exists."
-          exists=true
-        fi
+          # export result to output
+          echo "Latest commits: ${commits}"
+          echo "commits=${commits}" >> ${GITHUB_OUTPUT}
 
-        # export result to output
-        echo "exists=${exists}" >> ${GITHUB_OUTPUT}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Package assets into archive
+        id: package_asset
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          # set package values
+          name="${{ steps.get_metadata.outputs.namespace }}"
+          version="${{ steps.get_metadata.outputs.version }}"
+          arch="${{ steps.get_metadata.outputs.arch }}"
+          asset="${name}_${version}_${arch}.tar.gz"
 
-    - name: Get previous release tag
-      id: get_prev_tag
-      if: steps.check_release.outputs.exists == 'false'
-      run: |
-        # determine previous tag
-        prev_tag=$(git describe --tags --abbrev=0 HEAD^ || echo "")
+          # package required assets into a tar.gz file
+          tar -czvf "${asset}" bin doc ServiceMenus *.sh README.md
 
-        # check if previous tag exists
-        if [ -z "${prev_tag}" ]; then
-          echo "No previous tag found, this might be the first release."
-          prev_tag="HEAD" # use HEAD to include all commits
-        fi
+          # export asset path
+          echo "asset=${asset}" >> ${GITHUB_OUTPUT}
 
-        # export result to output
-        echo "Previous version: ${prev_tag}"
-        echo "prev_tag=${prev_tag}" >> ${GITHUB_OUTPUT}
+      - name: Create GitHub release
+        id: create_release
+        if: steps.package_asset.conclusion == 'success'
+        run: |
+          # determine main branch
+          main_branch=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
+          # decode the commit messages
+          decoded_commits=$(echo "${{ steps.get_commits.outputs.commits }}" | base64 --decode)
+          # prepare release notes
+          release_notes="Release v${{ steps.get_metadata.outputs.version }}.\n\n**Changes**:\n\n${decoded_commits}"
 
-    - name: Get commit messages since last release
-      id: get_commits
-      if: steps.check_release.outputs.exists == 'false'
-      run: |
-        # get previous version
-        prev_version="${{ steps.get_prev_tag.outputs.prev_tag }}"
+          # create release
+          gh release create "v${{ steps.get_metadata.outputs.version }}" \
+            --title "v${{ steps.get_metadata.outputs.version }}" \
+            --notes "$(echo -e "${release_notes}")" \
+            --target "${main_branch}" \
+            --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-        # get commits between versions
-        if [[ "${prev_version}" == "HEAD" ]]; then
-          commits="$(git log --oneline | base64 -w 0)"
-        else
-          commits="$(git log "${prev_version}"..HEAD --oneline | base64 -w 0)"
-        fi
-
-        # export result to output
-        echo "Latest commits: ${commits}"
-        echo "commits=${commits}" >> ${GITHUB_OUTPUT}
-
-    - name: Package assets into archive
-      id: package_asset
-      if: steps.check_release.outputs.exists == 'false'
-      run: |
-        # set package values
-        name="${{ steps.get_metadata.outputs.namespace }}"
-        version="${{ steps.get_metadata.outputs.version }}"
-        arch="${{ steps.get_metadata.outputs.arch }}"
-        asset="${name}_${version}_${arch}.tar.gz"
-
-        # package required assets into a tar.gz file
-        tar -czvf "${asset}" bin doc ServiceMenus *.sh README.md
-
-        # export asset path
-        echo "asset=${asset}" >> ${GITHUB_OUTPUT}
-
-    - name: Create GitHub release
-      id: create_release
-      if: steps.package_asset.conclusion == 'success'
-      run: |
-        # determine main branch
-        main_branch=$(git remote show origin | awk '/HEAD branch/ {print $NF}')
-        # decode the commit messages
-        decoded_commits=$(echo "${{ steps.get_commits.outputs.commits }}" | base64 --decode)
-        # prepare release notes
-        release_notes="Release v${{ steps.get_metadata.outputs.version }}.\n\n**Changes**:\n\n${decoded_commits}"
-
-        # create release
-        gh release create "v${{ steps.get_metadata.outputs.version }}" \
-          --title "v${{ steps.get_metadata.outputs.version }}" \
-          --notes "$(echo -e "${release_notes}")" \
-          --target "${main_branch}" \
-          --generate-notes
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Upload assets to release
-      id: upload_asset
-      if: steps.package_asset.conclusion == 'success' && steps.create_release.conclusion == 'success'
-      run: |
-        # upload asset to the GitHub release
-        gh release upload "v${{ steps.get_metadata.outputs.version }}" "${{ steps.package_asset.outputs.asset }}"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload assets to release
+        id: upload_asset
+        if: steps.package_asset.conclusion == 'success' && steps.create_release.conclusion == 'success'
+        run: |
+          # upload asset to the GitHub release
+          gh release upload "v${{ steps.get_metadata.outputs.version }}" "${{ steps.package_asset.outputs.asset }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
           echo "exists=${exists}" | tee -a ${GITHUB_OUTPUT}
 
       - name: Commit and push updated files
-        id: commit_changes
+        id: push_changes
         if: steps.check_changes.outputs.exists == 'true'
         run: |
           # set variables

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
         # export result to output
         echo "exists=${exists}" >> ${GITHUB_OUTPUT}
 
-    - name: Commit updated files
+    - name: Commit and push updated files
       id: commit_changes
       if: steps.check_changes.outputs.exists == 'true'
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
       - master                    # monitor changes only in the master branch
     paths:
       - doc/package.conf          # monitor changes to the package metadata file
+  workflow_dispatch:              # allow manually triggering the workflow
 
 env:
   GH_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,9 @@ on:
 permissions:
   contents: write
 
+env:
+  GH_TOKEN: ${{ secrets.GH_ACTIONS_TOKEN }}
+
 jobs:
   metadata:
     runs-on: ubuntu-latest
@@ -25,6 +28,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
+          token: ${{ env.GH_TOKEN }}
           fetch-depth: 0
 
       - name: Source metadata file and export variables
@@ -54,6 +58,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
+          token: ${{ env.GH_TOKEN }}
           fetch-depth: 0
 
       - name: Check if release exists
@@ -85,6 +90,7 @@ jobs:
         id: checkout
         uses: actions/checkout@v3
         with:
+          token: ${{ env.GH_TOKEN }}
           fetch-depth: 0
 
       - name: Update version in source files

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -12,7 +12,7 @@ provides=()
 conflicts=('kde-service-menu-reimage' 'kde-service-menu-reimage-mod')
 replaces=()
 source=("${url}/releases/download/v${pkgver}/kde-service-menu-reimage_${pkgver}_${arch[0]}.tar.gz")
-md5sums=('SKIP')
+md5sums=('acc6ec84363579911b366e62ff79bb22')
 
 package() {
     # determine installation paths

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -15,18 +15,17 @@ source=("${url}/releases/download/v${pkgver}/kde-service-menu-reimage_${pkgver}_
 md5sums=('SKIP')
 
 package() {
-    cd "kde-service-menu-reimage_${pkgver}_any"
     # determine installation paths
     bin_dir="$(qtpaths --install-prefix)/bin"
     servicemenu_dir="$(qtpaths --locate-dirs GenericDataLocation kio/servicemenus | sed 's/.*://')"
     doc_dir="$(qtpaths --install-prefix)/share/doc/kde-service-menu-reimage/"
     # install required binaries
-    install -d "${bin_dir}" && \
-    install -m 755 -p bin/* "${bin_dir}" && \
+    install -d "${pkgdir}${bin_dir}" && \
+    install -m 755 -p "${srcdir}"/bin/* "${pkgdir}${bin_dir}" && \
     # install required service menus
-    install -d "${servicemenu_dir}" && \
-    install -m 755 -p ServiceMenus/*.desktop "${servicemenu_dir}" && \
+    install -d "${pkgdir}${servicemenu_dir}" && \
+    install -m 755 -p "${srcdir}"/ServiceMenus/*.desktop "${pkgdir}${servicemenu_dir}" && \
     # install documentation files
-    install -d "${doc_dir}" && \
-    install -m 644 -p doc/* "${doc_dir}"
+    install -d "${pkgdir}${doc_dir}" && \
+    install -m 644 -p "${srcdir}"/doc/* "${pkgdir}${doc_dir}"
 }

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -26,7 +26,6 @@ package() {
     bin_dir="$(qtpaths --install-prefix)/bin"
     servicemenu_dir="$(qtpaths --locate-dirs GenericDataLocation kio/servicemenus | sed 's/.*://')"
     doc_dir="$(qtpaths --install-prefix)/share/doc/kde-service-menu-reimage/"
-
     # install required binaries
     install -d "${bin_dir}" && \
     install -m 755 -p bin/* "${bin_dir}" && \

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -11,7 +11,7 @@ optdepends=('jhead: required for extracting exif data')
 provides=()
 conflicts=('kde-service-menu-reimage' 'kde-service-menu-reimage-mod')
 replaces=()
-source=("${url}/releases/download/v${pkgver}/kde-service-menu-reimage_${pkgver}_any.tar.gz")
+source=("${url}/releases/download/v${pkgver}/kde-service-menu-reimage_${pkgver}_${arch[0]}.tar.gz")
 md5sums=('SKIP')
 
 package() {

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,0 +1,40 @@
+# Maintainer: Irfan Hakim <irfanhakim.as@yahoo.com>
+pkgname='kf6-service-menu-reimage'
+pkgver=VERSION
+pkgrel=1
+pkgdesc="Manipulate images e their metadata"
+arch=('any')
+url="https://github.com/irfanhakim-as/kde-service-menu-reimage"
+license=('GPL-3.0+')
+depends=('dolphin' 'imagemagick' 'kdialog')
+optdepends=('jhead: required for extracting exif data')
+provides=()
+conflicts=('kde-service-menu-reimage' 'kde-service-menu-reimage-mod')
+replaces=()
+source=("${url}/releases/download/v${pkgver}/kde-service-menu-reimage_${pkgver}_any.tar.gz")
+md5sums=('SKIP')
+
+pkgver() {
+    cd "kde-service-menu-reimage_${pkgver}_any"
+    source ./doc/package.conf
+    echo "${__version__}"
+}
+
+package() {
+	cd "kde-service-menu-reimage_${pkgver}_any"
+
+    # determine installation paths
+    bin_dir="$(qtpaths --install-prefix)/bin"
+    servicemenu_dir="$(qtpaths --locate-dirs GenericDataLocation kio/servicemenus | sed 's/.*://')"
+    doc_dir="$(qtpaths --install-prefix)/share/doc/kde-service-menu-reimage/"
+
+    # install required binaries
+    install -d "${bin_dir}" && \
+    install -m 755 -p bin/* "${bin_dir}" && \
+    # install required service menus
+    install -d "${servicemenu_dir}" && \
+    install -m 755 -p ServiceMenus/*.desktop "${servicemenu_dir}" && \
+    # install documentation files
+    install -d "${doc_dir}" && \
+    install -m 644 -p doc/* "${doc_dir}"
+}

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Irfan Hakim <irfanhakim.as@yahoo.com>
 pkgname='kf6-service-menu-reimage'
-pkgver=VERSION
+pkgver=2.6.0
 pkgrel=1
 pkgdesc="Manipulate images e their metadata"
 arch=('any')
@@ -13,12 +13,6 @@ conflicts=('kde-service-menu-reimage' 'kde-service-menu-reimage-mod')
 replaces=()
 source=("${url}/releases/download/v${pkgver}/kde-service-menu-reimage_${pkgver}_any.tar.gz")
 md5sums=('SKIP')
-
-pkgver() {
-    cd "kde-service-menu-reimage_${pkgver}_any"
-    source ./doc/package.conf
-    echo "${__version__}"
-}
 
 package() {
     cd "kde-service-menu-reimage_${pkgver}_any"

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -21,8 +21,7 @@ pkgver() {
 }
 
 package() {
-	cd "kde-service-menu-reimage_${pkgver}_any"
-
+    cd "kde-service-menu-reimage_${pkgver}_any"
     # determine installation paths
     bin_dir="$(qtpaths --install-prefix)/bin"
     servicemenu_dir="$(qtpaths --locate-dirs GenericDataLocation kio/servicemenus | sed 's/.*://')"


### PR DESCRIPTION
# Changes

- Added a PKGBUILD file to install the service menu on Arch Linux systems
- Updated `release` workflow:
  - Updated indentation
  - Separated groups of steps into multiple jobs for better handling
  - Added steps to update PKGBUILD and .SRCINFO
  - Replaced using `GITHUB_TOKEN` with secret PAT in order to trigger other workflows if need be
  - Updated name of the workflow to suit new role
  - Allowed workflow to be triggered manually if need be
- Added new `aur` workflow for updating PKGBUILD and .SRCINFO in AUR remote (tested in GitLab, yet to be seen if works on aur.archlinux.org)
- Added package .SRCINFO

# Notes

AUR remote is planned to be: `ssh://aur@aur.archlinux.org/kf6-service-menu-reimage.git` (`kf6-service-menu-reimage` being the name of the package)