### PR TITLE
Rename package as kf6-servicemenus-reimage

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,4 +1,4 @@
-pkgbase = kf6-service-menu-reimage
+pkgbase = kf6-servicemenus-reimage
 	pkgdesc = Manipulate images e their metadata
 	pkgver = 2.6.0
 	pkgrel = 1
@@ -14,4 +14,4 @@ pkgbase = kf6-service-menu-reimage
 	source = https://github.com/irfanhakim-as/kde-service-menu-reimage/releases/download/v2.6.0/kde-service-menu-reimage_2.6.0_any.tar.gz
 	md5sums = acc6ec84363579911b366e62ff79bb22
 
-pkgname = kf6-service-menu-reimage
+pkgname = kf6-servicemenus-reimage

--- a/.github/workflows/aur.yml
+++ b/.github/workflows/aur.yml
@@ -13,7 +13,7 @@ env:
   REMOTE_HOST_USER: aur
   REMOTE_HOST_PREFIX: ssh
   REMOTE_REPO_NAMESPACE: ''
-  REMOTE_REPO_NAME: kf6-service-menu-reimage
+  REMOTE_REPO_NAME: kf6-servicemenus-reimage
   REMOTE_REPO_USER: irfanhakim
   REMOTE_REPO_EMAIL: irfanhakim.as@yahoo.com
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,5 +1,5 @@
 # Maintainer: Irfan Hakim <irfanhakim.as@yahoo.com>
-pkgname='kf6-service-menu-reimage'
+pkgname='kf6-servicemenus-reimage'
 pkgver=2.6.0
 pkgrel=1
 pkgdesc="Manipulate images e their metadata"


### PR DESCRIPTION
Will merge, as soon as the [merge request](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/thread/QIVNBHWLDQIEG3CI7SP7FOCCR5HQQQZR) on the AUR (to merge the old package base into the new one) gets through.