### PR TITLE
Add `qt5-tools` to make dependency

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,6 +7,7 @@ arch=('any')
 url="https://github.com/irfanhakim-as/kde-service-menu-reimage"
 license=('GPL-3.0+')
 depends=('dolphin' 'imagemagick' 'kdialog')
+makedepends=('qt5-tools')
 optdepends=('jhead: required for extracting exif data')
 provides=()
 conflicts=('kde-service-menu-reimage' 'kde-service-menu-reimage-mod')

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Irfan Hakim <irfanhakim.as@yahoo.com>
 pkgname='kf6-servicemenus-reimage'
 pkgver=2.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Manipulate images e their metadata"
 arch=('any')
 url="https://github.com/irfanhakim-as/kde-service-menu-reimage"


### PR DESCRIPTION
# Changes

- Added `qt5-tools` as make dependency in PKGBUILD

# Notes

Installation script in PKGBUILD requires `qtpaths` which is provided by both [qt5-tools](https://archlinux.org/packages/extra/x86_64/qt5-tools) (`/usr/bin/qtpaths`) and [qt6-base](https://archlinux.org/packages/extra/x86_64/qt6-base) (`usr/lib/qt6/bin/qtpaths`). The install script works and behaves the same with both, and ideally I would've made the `makedepends` to use whichever of the two is installed if any, but I don't think that's possible.

`qt6-base` is included in current `plasma-desktop` installation, while `qt5-tools` isn't and may only be included in systems that had updated from KDE Plasma 5 to Plasma 6. At least for now though, setting `qt5-tools` as the make dependency may be preferred in favour of KDE Plasma 5 compatibility (probably) and because it installs a lot less packages (which can be removed post-install if need be).

# Related issues

- #10