### PR TITLE
Change abort logic on "manage_input_separately"

### DIFF
--- a/bin/reimage-kdialog
+++ b/bin/reimage-kdialog
@@ -977,7 +977,7 @@ manage_input_separately () {
 	[ "${ask_overwrite}" = true ] && do_you_want_to_overwrite
 
 	quantity=$#
-	dbus_ref=$(kdialog --icon configure --title "${!msg_title}" --progressbar "${msg_common_start}" $quantity showCancelButton true)
+	dbus_ref=$(kdialog --icon configure --title "${!msg_title}" --progressbar "${msg_common_start}" $quantity)
 	processed=0
 
 	for input in "$@"; do

--- a/bin/reimage-kdialog
+++ b/bin/reimage-kdialog
@@ -977,32 +977,32 @@ manage_input_separately () {
 	[ "${ask_overwrite}" = true ] && do_you_want_to_overwrite
 
 	quantity=$#
-	dbus_ref=$("${kdialog_bin}" --icon configure --title "${!msg_title}" --progressbar "${msg_common_start}" $quantity)
-	qdbus $dbus_ref showCancelButton true
+	dbus_ref=$(kdialog --icon configure --title "${!msg_title}" --progressbar "${msg_common_start}" $quantity showCancelButton true)
 	processed=0
 
 	for input in "$@"; do
-		## Check if cancel button has been pushed
-		[ "$(qdbus $dbus_ref wasCancelled)" = "true" ] && \
-			qdbus $dbus_ref close && "${kdialog_bin}" --title "${!msg_title}" --passivepopup "${msg_common_abort}" 5 && exit 2;
+		## Check if window has been closed w. cancel / alt + f4...
+		if [ "$?" = 0 ]; then
+			dir=$(dirname -- "${input}")
+			name="${input##*/}"
+			base="${name%.*}"
+			ext="${name##*.}"
 
-		dir=$(dirname -- "${input}")
-		name="${input##*/}"
-		base="${name%.*}"
-		ext="${name##*.}"
+			processed=$(($processed + 1))
+			load_language
 
-		processed=$(($processed + 1))
-		load_language
+			[ ! -f "${input}" ] && "${kdialog_bin}" --title --icon configure "${!msg_title}" --error "${msg_common_file_not_found}" && break
+			qdbus $dbus_ref setLabelText "${msg_common_progress_text}"
 
-		[ ! -f "${input}" ] && "${kdialog_bin}" --title --icon configure "${!msg_title}" --error "${msg_common_file_not_found}" && break
-		qdbus $dbus_ref setLabelText "${msg_common_progress_text}"
+			msg_finish_title=msg_${action}_finish_title
+			run_${action} && \
+				"${kdialog_bin}" --title "${!msg_finish_title}" --passivepopup "${msg_common_finish_ok}" 5 || \
+				{ qdbus $dbus_ref close; "${kdialog_bin}" --icon configure --title "${!msg_finish_title}" --detailederror "${msg_common_finish_error}" "${msg}"; exit 2; }
 
-		# msg_finish_title=msg_${action}_finish_title
-		run_${action} && \
-			"${kdialog_bin}" --title "${!msg_finish_title}" --passivepopup "${msg_common_finish_ok}" 5 || \
-			{ qdbus $dbus_ref close; "${kdialog_bin}" --icon configure --title "${!msg_finish_title}" --detailederror "${msg_common_finish_error}" "${msg}"; exit 2; }
-
-		qdbus $dbus_ref org.freedesktop.DBus.Properties.Set org.kde.kdialog.ProgressDialog value $processed
+			qdbus $dbus_ref org.freedesktop.DBus.Properties.Set org.kde.kdialog.ProgressDialog value $processed
+		else	
+			"${kdialog_bin}" --title "${!msg_title}" --passivepopup "${msg_common_abort}" 5 && exit 2;
+		fi
 	done
 
 	qdbus $dbus_ref close


### PR DESCRIPTION
Fixes an issue reported on this [branch](https://github.com/eclipseo/reimage/issues/8)

This checks instead if the window has been closed in any way (Cancel, alt + f4...).

This works better for the average user who expect the program to be the "window".

The old logic (assuming it worked) would've only accounted the "Cancel" press, not an alt + f4 for example.

